### PR TITLE
feat: add new options to make error definition easier

### DIFF
--- a/new.go
+++ b/new.go
@@ -15,8 +15,12 @@ func new(err error) error {
 }
 
 // New ...
-func New(msg string) error {
+func New(msg string, opts ...NewErrorOptions) error {
 	newError := eris.New(msg)
+	for _, opt := range opts {
+		newError = opt(newError)
+	}
+
 	return new(newError)
 }
 

--- a/new.go
+++ b/new.go
@@ -15,7 +15,7 @@ func new(err error) error {
 }
 
 // New ...
-func New(msg string, opts ...NewErrorOptions) error {
+func New(msg string, opts ...NewErrorOption) error {
 	newError := eris.New(msg)
 	for _, opt := range opts {
 		newError = opt(newError)

--- a/new_test.go
+++ b/new_test.go
@@ -1,6 +1,7 @@
 package roxy
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -12,18 +13,84 @@ func TestNew(t *testing.T) {
 }
 
 func testNew(t *testing.T) {
-	baseString := "BaseError"
-	err := New(baseString)
+	tests := []struct {
+		name string
+		opts []NewErrorOptions
+	}{
+		{
+			name: "WithMessageAction",
+			opts: []NewErrorOptions{
+				WithMessageAction(DropMessageAction),
+			},
+		},
+		{
+			name: "WithHTTPResponse",
+			opts: []NewErrorOptions{
+				WithHTTPResponse(HTTPResponse{
+					Message: "test",
+					Status:  200,
+				}),
+			},
+		},
+		{
+			name: "WithGrpcResponse",
+			opts: []NewErrorOptions{
+				WithGrpcResponse(GrpcResponse{
+					Message: "test",
+					Code:    0,
+				}),
+			},
+		},
+		{
+			name: "WithLogLevel",
+			opts: []NewErrorOptions{
+				WithLogLevel(DebugLevel),
+			},
+		},
+		{
+			name: "WithPublicError",
+			opts: []NewErrorOptions{
+				WithPublicError(errors.New("test")),
+			},
+		},
+		{
+			name: "WithMessageAction, WithHTTPResponse, WithGrpcResponse, WithLogLevel, WithPublicError",
+			opts: []NewErrorOptions{
+				WithMessageAction(DropMessageAction),
+				WithHTTPResponse(HTTPResponse{
+					Message: "test",
+					Status:  200,
+				}),
+				WithGrpcResponse(GrpcResponse{
+					Message: "test",
+					Code:    0,
+				}),
+				WithLogLevel(DebugLevel),
+				WithPublicError(errors.New("test")),
+			},
+		},
+		{
+			name: "BaseError",
+			opts: []NewErrorOptions{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseString := tt.name
+			err := New(baseString, tt.opts...)
 
-	stringError := err.Error()
-	if stringError != baseString {
-		t.Errorf("%s is not equal to %s", stringError, baseString)
+			stringError := err.Error()
+			if stringError != baseString {
+				t.Errorf("%s is not equal to %s", stringError, baseString)
+			}
+
+			_, ok := err.(*detailedError)
+			if !ok {
+				t.Error("Could not cast to DetailedError")
+			}
+		})
 	}
 
-	_, ok := err.(*detailedError)
-	if !ok {
-		t.Error("Could not cast to DetailedError")
-	}
 }
 
 func testErrorf(t *testing.T) {

--- a/new_test.go
+++ b/new_test.go
@@ -15,17 +15,17 @@ func TestNew(t *testing.T) {
 func testNew(t *testing.T) {
 	tests := []struct {
 		name string
-		opts []NewErrorOptions
+		opts []NewErrorOption
 	}{
 		{
 			name: "WithMessageAction",
-			opts: []NewErrorOptions{
+			opts: []NewErrorOption{
 				WithMessageAction(DropMessageAction),
 			},
 		},
 		{
 			name: "WithHTTPResponse",
-			opts: []NewErrorOptions{
+			opts: []NewErrorOption{
 				WithHTTPResponse(HTTPResponse{
 					Message: "test",
 					Status:  200,
@@ -34,7 +34,7 @@ func testNew(t *testing.T) {
 		},
 		{
 			name: "WithGrpcResponse",
-			opts: []NewErrorOptions{
+			opts: []NewErrorOption{
 				WithGrpcResponse(GrpcResponse{
 					Message: "test",
 					Code:    0,
@@ -43,19 +43,19 @@ func testNew(t *testing.T) {
 		},
 		{
 			name: "WithLogLevel",
-			opts: []NewErrorOptions{
+			opts: []NewErrorOption{
 				WithLogLevel(DebugLevel),
 			},
 		},
 		{
 			name: "WithPublicError",
-			opts: []NewErrorOptions{
+			opts: []NewErrorOption{
 				WithPublicError(errors.New("test")),
 			},
 		},
 		{
 			name: "WithMessageAction, WithHTTPResponse, WithGrpcResponse, WithLogLevel, WithPublicError",
-			opts: []NewErrorOptions{
+			opts: []NewErrorOption{
 				WithMessageAction(DropMessageAction),
 				WithHTTPResponse(HTTPResponse{
 					Message: "test",
@@ -71,7 +71,7 @@ func testNew(t *testing.T) {
 		},
 		{
 			name: "BaseError",
-			opts: []NewErrorOptions{},
+			opts: []NewErrorOption{},
 		},
 	}
 	for _, tt := range tests {

--- a/options.go
+++ b/options.go
@@ -1,32 +1,32 @@
 package roxy
 
-type NewErrorOptions func(error) error
+type NewErrorOption func(error) error
 
-func WithMessageAction(defaultMessageAction MessageAction) NewErrorOptions {
+func WithMessageAction(defaultMessageAction MessageAction) NewErrorOption {
 	return func(err error) error {
 		return SetDefaultMessageAction(err, defaultMessageAction)
 	}
 }
 
-func WithHTTPResponse(defaultHTTPResponse HTTPResponse) NewErrorOptions {
+func WithHTTPResponse(defaultHTTPResponse HTTPResponse) NewErrorOption {
 	return func(err error) error {
 		return SetDefaultHTTPResponse(err, defaultHTTPResponse)
 	}
 }
 
-func WithGrpcResponse(defaultGrpcResponse GrpcResponse) NewErrorOptions {
+func WithGrpcResponse(defaultGrpcResponse GrpcResponse) NewErrorOption {
 	return func(err error) error {
 		return SetDefaultGrpcResponse(err, defaultGrpcResponse)
 	}
 }
 
-func WithLogLevel(defaultLogLevel LogLevel) NewErrorOptions {
+func WithLogLevel(defaultLogLevel LogLevel) NewErrorOption {
 	return func(err error) error {
 		return SetErrorLogLevel(err, defaultLogLevel)
 	}
 }
 
-func WithPublicError(defaultPublicError error) NewErrorOptions {
+func WithPublicError(defaultPublicError error) NewErrorOption {
 	return func(err error) error {
 		return SetPublicError(err, defaultPublicError)
 	}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,33 @@
+package roxy
+
+type NewErrorOptions func(error) error
+
+func WithMessageAction(defaultMessageAction MessageAction) NewErrorOptions {
+	return func(err error) error {
+		return SetDefaultMessageAction(err, defaultMessageAction)
+	}
+}
+
+func WithHTTPResponse(defaultHTTPResponse HTTPResponse) NewErrorOptions {
+	return func(err error) error {
+		return SetDefaultHTTPResponse(err, defaultHTTPResponse)
+	}
+}
+
+func WithGrpcResponse(defaultGrpcResponse GrpcResponse) NewErrorOptions {
+	return func(err error) error {
+		return SetDefaultGrpcResponse(err, defaultGrpcResponse)
+	}
+}
+
+func WithLogLevel(defaultLogLevel LogLevel) NewErrorOptions {
+	return func(err error) error {
+		return SetErrorLogLevel(err, defaultLogLevel)
+	}
+}
+
+func WithPublicError(defaultPublicError error) NewErrorOptions {
+	return func(err error) error {
+		return SetPublicError(err, defaultPublicError)
+	}
+}


### PR DESCRIPTION
# What is this PR doing

- adding roxy.New(...) options so we can add meta information inside the creation function. For example:
```go
err := roxy.New("internal server error",
    roxy.WithHTTPResponse(roxy.UnhandledHTTPResponse),
    roxy.WithGrpcResponse(roxy.UnhandledErrorGrpcResponse),
    roxy.WithMessageAction(roxy.RequeueMessageAction),
    roxy.WithLogLevel(roxy.ErrorLevel))
    
// or maybe set a default error options for a group:
// I know it sounds wierd
successErrorOpts := []roxy.NewErrorOption{
    roxy.WithHTTPResponse(roxy.OkHTTPResponse),
    roxy.WithGrpcResponse(roxy.OKGrpcResponse),
    roxy.WithMessageAction(roxy.SuccessMessageAction),
    roxy.WithLogLevel(roxy.InfoLevel)
}

var (
    successErr1 = roxy.New("something happend but we treat it as a success", successErrorOpts...)
    successErr2 = roxy.New("another thing happend but we also treat it as a success", successErrorOpts...)
)

```